### PR TITLE
Specific user posts, edit posts, soft delete posts, show read time, show all users as admin

### DIFF
--- a/TabloidMVC/Controllers/AccountController.cs
+++ b/TabloidMVC/Controllers/AccountController.cs
@@ -38,6 +38,7 @@ namespace TabloidMVC.Controllers
             {
                 new Claim(ClaimTypes.NameIdentifier, userProfile.Id.ToString()),
                 new Claim(ClaimTypes.Email, userProfile.Email),
+                new Claim(ClaimTypes.Role, userProfile.UserType.Name)
             };
 
             var claimsIdentity = new ClaimsIdentity(

--- a/TabloidMVC/Controllers/PostController.cs
+++ b/TabloidMVC/Controllers/PostController.cs
@@ -5,7 +5,7 @@ using Microsoft.VisualBasic;
 using System.Security.Claims;
 using TabloidMVC.Models.ViewModels;
 using TabloidMVC.Repositories;
-
+using TabloidMVC.Models;
 namespace TabloidMVC.Controllers
 {
     [Authorize]
@@ -23,6 +23,12 @@ namespace TabloidMVC.Controllers
         public IActionResult Index()
         {
             var posts = _postRepository.GetAllPublishedPosts();
+            return View(posts);
+        }
+
+        public IActionResult UserIndex()
+        {
+            var posts = _postRepository.GetUserPostsById(GetCurrentUserProfileId());
             return View(posts);
         }
 
@@ -66,6 +72,70 @@ namespace TabloidMVC.Controllers
                 vm.CategoryOptions = _categoryRepository.GetAll();
                 return View(vm);
             }
+        }
+
+        public IActionResult Edit(int id)
+        {
+            var post = _postRepository.GetPublishedPostById(id);
+            var categories = _categoryRepository.GetAll();
+            PostCreateViewModel vm = new PostCreateViewModel
+            {
+                Post = post,
+                CategoryOptions = categories
+            };
+
+            return View(vm);
+        }
+
+        [HttpPost]
+        public IActionResult Edit(int id, Post post)
+        {
+
+
+            try
+            {
+                _postRepository.UpdatePost(post);
+                return RedirectToAction("Details", new { id = post.Id });
+            }
+            catch
+            {
+
+          
+           
+            
+                var postToView = _postRepository.GetPublishedPostById(id);
+                var categories = _categoryRepository.GetAll();
+                PostCreateViewModel vm = new PostCreateViewModel
+                {
+                    Post = postToView,
+                    CategoryOptions = categories
+                };
+                return View(vm);
+
+            }
+        }
+
+        public IActionResult Delete(int id)
+        {
+            Post post = _postRepository.GetPublishedPostById(id);
+
+            return View(post);
+        }
+
+        [HttpPost]
+        public IActionResult Delete(Post post)
+        {
+            try
+            {
+                _postRepository.DeletePost(post.Id);
+                return RedirectToAction($"Details", new { id = post.Id });
+            }
+            catch
+            {
+                return View(post);
+            }
+
+            
         }
 
         private int GetCurrentUserProfileId()

--- a/TabloidMVC/Controllers/PostController.cs
+++ b/TabloidMVC/Controllers/PostController.cs
@@ -76,7 +76,9 @@ namespace TabloidMVC.Controllers
 
         public IActionResult Edit(int id)
         {
-            var post = _postRepository.GetPublishedPostById(id);
+            var post = new Post();
+            int userId = GetCurrentUserProfileId();
+            post = _postRepository.GetUserPostById(id, userId);
             var categories = _categoryRepository.GetAll();
             PostCreateViewModel vm = new PostCreateViewModel
             {

--- a/TabloidMVC/Controllers/UserController.cs
+++ b/TabloidMVC/Controllers/UserController.cs
@@ -1,0 +1,100 @@
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.VisualBasic;
+using System.Security.Claims;
+using TabloidMVC.Models.ViewModels;
+using TabloidMVC.Repositories;
+using TabloidMVC.Models;
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http;
+
+namespace TabloidMVC.Controllers
+{
+    [Authorize]
+    public class UserController : Controller
+    {
+        private readonly IUserProfileRepository _userRepo;
+
+
+        public UserController(IUserProfileRepository userRepository)
+        {
+            _userRepo = userRepository;
+        }
+        // GET: UserController
+        public ActionResult Index()
+        {
+            List<UserProfile> userProfiles = _userRepo.GetAllUserProfiles();
+            return View(userProfiles);
+        }
+
+        // GET: UserController/Details/5
+        public ActionResult Details(int id)
+        {
+            return View();
+        }
+
+        // GET: UserController/Create
+        public ActionResult Create()
+        {
+            return View();
+        }
+
+        // POST: UserController/Create
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult Create(IFormCollection collection)
+        {
+            try
+            {
+                return RedirectToAction(nameof(Index));
+            }
+            catch
+            {
+                return View();
+            }
+        }
+
+        // GET: UserController/Edit/5
+        public ActionResult Edit(int id)
+        {
+            return View();
+        }
+
+        // POST: UserController/Edit/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult Edit(int id, IFormCollection collection)
+        {
+            try
+            {
+                return RedirectToAction(nameof(Index));
+            }
+            catch
+            {
+                return View();
+            }
+        }
+
+        // GET: UserController/Delete/5
+        public ActionResult Delete(int id)
+        {
+            return View();
+        }
+
+        // POST: UserController/Delete/5
+        [HttpPost]
+        [ValidateAntiForgeryToken]
+        public ActionResult Delete(int id, IFormCollection collection)
+        {
+            try
+            {
+                return RedirectToAction(nameof(Index));
+            }
+            catch
+            {
+                return View();
+            }
+        }
+    }
+}

--- a/TabloidMVC/Models/Post.cs
+++ b/TabloidMVC/Models/Post.cs
@@ -13,14 +13,15 @@ namespace TabloidMVC.Models
 
         [Required]
         public string Content { get; set; }
-
+        [Required]
         [DisplayName("Header Image URL")]
         public string ImageLocation { get; set; }
-
+        [Required]
         public DateTime CreateDateTime { get; set; }
 
         [DisplayName("Published")]
         [DataType(DataType.Date)]
+        
         public DateTime? PublishDateTime { get; set; }
 
         public bool IsApproved { get; set; }
@@ -33,5 +34,17 @@ namespace TabloidMVC.Models
         [DisplayName("Author")]
         public int UserProfileId { get; set; }
         public UserProfile UserProfile { get; set; }
+
+        
+
+        public double calculateReadTime()
+        {
+            double time = 0;
+            double test = Content.Split(" ").Length;
+            time =  test / 265;
+            time = Math.Ceiling(time);
+
+            return time;
+        }
     }
 }

--- a/TabloidMVC/Models/UserProfile.cs
+++ b/TabloidMVC/Models/UserProfile.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Data.SqlClient.Server;
 using System;
+using System.ComponentModel;
 using System.Runtime.Intrinsics.X86;
 
 namespace TabloidMVC.Models
@@ -13,6 +14,7 @@ namespace TabloidMVC.Models
         public string Email { get; set; }
         public DateTime CreateDateTime { get; set; }
         public string ImageLocation { get; set; }
+        [DisplayName("User Type")]
         public int UserTypeId { get; set; }
         public UserType UserType { get; set; }
         public string FullName

--- a/TabloidMVC/Repositories/IPostRepository.cs
+++ b/TabloidMVC/Repositories/IPostRepository.cs
@@ -9,5 +9,10 @@ namespace TabloidMVC.Repositories
         List<Post> GetAllPublishedPosts();
         Post GetPublishedPostById(int id);
         Post GetUserPostById(int id, int userProfileId);
+        List<Post> GetUserPostsById(int userProfileId);
+
+        void UpdatePost(Post post);
+
+        void DeletePost(int id);
     }
 }

--- a/TabloidMVC/Repositories/IUserProfileRepository.cs
+++ b/TabloidMVC/Repositories/IUserProfileRepository.cs
@@ -1,9 +1,11 @@
-﻿using TabloidMVC.Models;
+﻿using System.Collections.Generic;
+using TabloidMVC.Models;
 
 namespace TabloidMVC.Repositories
 {
     public interface IUserProfileRepository
     {
         UserProfile GetByEmail(string email);
+        List<UserProfile> GetAllUserProfiles();
     }
 }

--- a/TabloidMVC/Repositories/PostRepository.cs
+++ b/TabloidMVC/Repositories/PostRepository.cs
@@ -72,7 +72,7 @@ namespace TabloidMVC.Repositories
                               LEFT JOIN Category c ON p.CategoryId = c.id
                               LEFT JOIN UserProfile u ON p.UserProfileId = u.id
                               LEFT JOIN UserType ut ON u.UserTypeId = ut.id
-                        WHERE IsApproved = 1 AND PublishDateTime < SYSDATETIME()
+                        WHERE IsApproved = 1
                               AND p.id = @id ";
 
                     cmd.Parameters.AddWithValue("@id", id);
@@ -217,16 +217,17 @@ namespace TabloidMVC.Repositories
                         Title = @title,
                         Content = @content,
                         ImageLocation = @imageLocation,
+                        PublishDateTime = @publishDateTime,
                        
-                        IsApproved = @isApproved,
+                       
                         CategoryId = @categoryId
                         WHERE Id = @id";
 
                     cmd.Parameters.AddWithValue("@title", post.Title);
                     cmd.Parameters.AddWithValue("@content", post.Content);
                     cmd.Parameters.AddWithValue("@imageLocation", post.ImageLocation);
-                    
-                    cmd.Parameters.AddWithValue("@isApproved", post.IsApproved);
+                    cmd.Parameters.AddWithValue("@publishDateTime", post.PublishDateTime);
+
                     cmd.Parameters.AddWithValue("@categoryId", post.CategoryId);
                     cmd.Parameters.AddWithValue("@id", post.Id);
 

--- a/TabloidMVC/Repositories/PostRepository.cs
+++ b/TabloidMVC/Repositories/PostRepository.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
+using System.Reflection;
 using System.Reflection.PortableExecutable;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
@@ -33,7 +34,7 @@ namespace TabloidMVC.Repositories
                               LEFT JOIN Category c ON p.CategoryId = c.id
                               LEFT JOIN UserProfile u ON p.UserProfileId = u.id
                               LEFT JOIN UserType ut ON u.UserTypeId = ut.id
-                        WHERE IsApproved = 1 AND PublishDateTime < SYSDATETIME()";
+                        WHERE IsApproved = 1 AND PublishDateTime < SYSDATETIME() AND  p.IsDeleted = 0";
                     var reader = cmd.ExecuteReader();
 
                     var posts = new List<Post>();
@@ -72,7 +73,7 @@ namespace TabloidMVC.Repositories
                               LEFT JOIN UserProfile u ON p.UserProfileId = u.id
                               LEFT JOIN UserType ut ON u.UserTypeId = ut.id
                         WHERE IsApproved = 1 AND PublishDateTime < SYSDATETIME()
-                              AND p.id = @id";
+                              AND p.id = @id ";
 
                     cmd.Parameters.AddWithValue("@id", id);
                     var reader = cmd.ExecuteReader();
@@ -90,7 +91,48 @@ namespace TabloidMVC.Repositories
                 }
             }
         }
+        public List<Post> GetUserPostsById(int userProfileId)
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                       SELECT p.Id, p.Title, p.Content, 
+                              p.ImageLocation AS HeaderImage,
+                              p.CreateDateTime, p.PublishDateTime, p.IsApproved,
+                              p.CategoryId, p.UserProfileId,
+                              c.[Name] AS CategoryName,
+                              u.FirstName, u.LastName, u.DisplayName, 
+                              u.Email, u.CreateDateTime, u.ImageLocation AS AvatarImage,
+                              u.UserTypeId, 
+                              ut.[Name] AS UserTypeName
+                         FROM Post p
+                              LEFT JOIN Category c ON p.CategoryId = c.id
+                              LEFT JOIN UserProfile u ON p.UserProfileId = u.id
+                              LEFT JOIN UserType ut ON u.UserTypeId = ut.id
+                       
+                        WHERE p.UserProfileId = @userProfileId AND  p.IsDeleted = 0
+                        ORDER BY p.CreateDateTime";
 
+                    
+                    cmd.Parameters.AddWithValue("@userProfileId", userProfileId);
+                    var reader = cmd.ExecuteReader();
+
+                    List<Post> posts = new List<Post>();
+
+                    while (reader.Read())
+                    {
+                        posts.Add(NewPostFromReader(reader));
+                    }
+
+                    reader.Close();
+
+                    return posts;
+                }
+            }
+        }
         public Post GetUserPostById(int id, int userProfileId)
         {
             using (var conn = Connection)
@@ -112,7 +154,7 @@ namespace TabloidMVC.Repositories
                               LEFT JOIN Category c ON p.CategoryId = c.id
                               LEFT JOIN UserProfile u ON p.UserProfileId = u.id
                               LEFT JOIN UserType ut ON u.UserTypeId = ut.id
-                        WHERE p.id = @id AND p.UserProfileId = @userProfileId";
+                        WHERE p.id = @id AND p.UserProfileId = @userProfileId AND  p.IsDeleted = 0";
 
                     cmd.Parameters.AddWithValue("@id", id);
                     cmd.Parameters.AddWithValue("@userProfileId", userProfileId);
@@ -160,6 +202,63 @@ namespace TabloidMVC.Repositories
                     post.Id = (int)cmd.ExecuteScalar();
                 }
             }
+        }
+
+        public void UpdatePost(Post post)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        UPDATE Post
+                        SET
+                        Title = @title,
+                        Content = @content,
+                        ImageLocation = @imageLocation,
+                       
+                        IsApproved = @isApproved,
+                        CategoryId = @categoryId
+                        WHERE Id = @id";
+
+                    cmd.Parameters.AddWithValue("@title", post.Title);
+                    cmd.Parameters.AddWithValue("@content", post.Content);
+                    cmd.Parameters.AddWithValue("@imageLocation", post.ImageLocation);
+                    
+                    cmd.Parameters.AddWithValue("@isApproved", post.IsApproved);
+                    cmd.Parameters.AddWithValue("@categoryId", post.CategoryId);
+                    cmd.Parameters.AddWithValue("@id", post.Id);
+
+
+                    cmd.ExecuteNonQuery();
+
+                }
+            }
+        }
+
+        public void DeletePost(int id)
+        {
+            using (SqlConnection conn = Connection)
+            {
+                conn.Open();
+                using (SqlCommand cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        UPDATE Post
+                        SET
+                        IsDeleted = @isDeleted
+                        WHERE Id = @id";
+
+                    cmd.Parameters.AddWithValue("@isDeleted", 1);
+                    cmd.Parameters.AddWithValue("@id", id);
+
+
+                    cmd.ExecuteNonQuery();
+
+                }
+            }
+
         }
 
         private Post NewPostFromReader(SqlDataReader reader)

--- a/TabloidMVC/Repositories/UserProfileRepository.cs
+++ b/TabloidMVC/Repositories/UserProfileRepository.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Configuration;
+using System.Collections.Generic;
 using TabloidMVC.Models;
 using TabloidMVC.Utils;
 
@@ -50,6 +51,53 @@ namespace TabloidMVC.Repositories
                     reader.Close();
 
                     return userProfile;
+                }
+            }
+        }
+
+        public List<UserProfile> GetAllUserProfiles()
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                       SELECT u.id, u.FirstName, u.LastName, u.DisplayName, u.Email,
+                              u.CreateDateTime, u.ImageLocation, u.UserTypeId,
+                              ut.[Name] AS UserTypeName
+                         FROM UserProfile u
+                              LEFT JOIN UserType ut ON u.UserTypeId = ut.id
+                        ORDER BY u.DisplayName
+                       ";
+
+
+                    List<UserProfile> userProfiles = new List<UserProfile>();
+                    var reader = cmd.ExecuteReader();
+
+                    if (reader.Read())
+                    {
+                        userProfiles.Add(new UserProfile()
+                        {
+                            Id = reader.GetInt32(reader.GetOrdinal("Id")),
+                            Email = reader.GetString(reader.GetOrdinal("Email")),
+                            FirstName = reader.GetString(reader.GetOrdinal("FirstName")),
+                            LastName = reader.GetString(reader.GetOrdinal("LastName")),
+                            DisplayName = reader.GetString(reader.GetOrdinal("DisplayName")),
+                            CreateDateTime = reader.GetDateTime(reader.GetOrdinal("CreateDateTime")),
+                            ImageLocation = DbUtils.GetNullableString(reader, "ImageLocation"),
+                            UserTypeId = reader.GetInt32(reader.GetOrdinal("UserTypeId")),
+                            UserType = new UserType()
+                            {
+                                Id = reader.GetInt32(reader.GetOrdinal("UserTypeId")),
+                                Name = reader.GetString(reader.GetOrdinal("UserTypeName"))
+                            },
+                        });
+                    }
+
+                    reader.Close();
+
+                    return userProfiles;
                 }
             }
         }

--- a/TabloidMVC/TabloidMVC.csproj
+++ b/TabloidMVC/TabloidMVC.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.5" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.3" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.4" />
   </ItemGroup>
 
 </Project>

--- a/TabloidMVC/Views/Post/Create.cshtml
+++ b/TabloidMVC/Views/Post/Create.cshtml
@@ -24,7 +24,7 @@
                 </div>
                 <div class="form-group">
                     <label asp-for="Post.PublishDateTime" class="control-label"></label>
-                    <input asp-for="Post.PublishDateTime" class="form-control" />
+                    <input asp-for="Post.PublishDateTime" max="@DateTime.Now.ToShortDateString()" class="form-control" />
                     <span asp-validation-for="Post.PublishDateTime" class="text-danger"></span>
                 </div>
                 <div class="form-group">

--- a/TabloidMVC/Views/Post/Delete.cshtml
+++ b/TabloidMVC/Views/Post/Delete.cshtml
@@ -1,0 +1,59 @@
+﻿@model TabloidMVC.Models.Post
+
+@{
+    ViewData["Title"] = "Delete";
+}
+
+<h1>Delete</h1>
+
+<h3>Are you sure you want to delete this?</h3>
+<div>
+    <h4>Post</h4>
+    <hr />
+    <dl class="row">
+   
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.Title)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.Title)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.Content)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.Content)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.ImageLocation)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.ImageLocation)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.CreateDateTime)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.CreateDateTime)
+        </dd>
+       
+       
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.CategoryId)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.Category.Name)
+        </dd>
+        <dt class = "col-sm-2">
+            @Html.DisplayNameFor(model => model.UserProfileId)
+        </dt>
+        <dd class = "col-sm-10">
+            @Html.DisplayFor(model => model.UserProfile.DisplayName)
+        </dd>
+    </dl>
+    
+    <form asp-action="Delete">
+        <input type="submit" value="Delete" class="btn btn-danger" /> |
+        <a asp-action="UserIndex">Cancel</a>
+    </form>
+</div>

--- a/TabloidMVC/Views/Post/Details.cshtml
+++ b/TabloidMVC/Views/Post/Details.cshtml
@@ -14,6 +14,15 @@
             <div class="row justify-content-between">
                 <p class="text-secondary">Written by @Model.UserProfile.DisplayName</p>
                 <p class="text-black-50">Published on @Html.DisplayFor(model => model.PublishDateTime)</p>
+                @if (Model.calculateReadTime() == 1)
+                {
+                    <p class="text-black-50">Read Time: @Model.calculateReadTime() minute</p>
+                }
+                else
+                {
+                    <p class="text-black-50">Read Time: @Model.calculateReadTime() minutes</p>
+                }
+
             </div>
             <div class="row">
                 <a asp-action="Edit" asp-route-id="@Model.Id" class="btn btn-outline-primary mx-1" title="Edit">

--- a/TabloidMVC/Views/Post/Edit.cshtml
+++ b/TabloidMVC/Views/Post/Edit.cshtml
@@ -1,58 +1,65 @@
 ﻿@model TabloidMVC.Models.ViewModels.PostCreateViewModel
 
 @{
-    ViewData["Title"] = "Create";
+    ViewData["Title"] = "Edit";
 }
 
-
-
+<hr />
 <div class="container pt-5">
     <div class="row justify-content-center">
         <div class="card col-md-12 col-lg-8">
-            <h3 class="mt-3 text-primary text-center card-title">What do you have to say?</h3>
-            <form class="mt-5 card-body" asp-action="Create">
+            <h3 class="mt-3 text-primary text-center card-title">What do you want to edit?</h3>
+            <form class="mt-5 card-body" asp-action="Edit">
                 <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                <div class="form-group">
+                    <input asp-for="Post.Id" type="hidden" class="form-control" />
+
+                </div>
                 <div class="form-group">
                     <label asp-for="Post.Title" class="control-label"></label>
                     <input asp-for="Post.Title" class="form-control" />
                     <span asp-validation-for="Post.Title" class="text-danger"></span>
                 </div>
                 <div class="form-group">
+                    <label asp-for="Post.Content" class="control-label"></label>
+                    <input asp-for="Post.Content" class="form-control" />
+                    <span asp-validation-for="Post.Content" class="text-danger"></span>
+                </div>
+                <div class="form-group">
                     <label asp-for="Post.ImageLocation" class="control-label"></label>
                     <input asp-for="Post.ImageLocation" class="form-control" />
                     <span asp-validation-for="Post.ImageLocation" class="text-danger"></span>
                 </div>
-                <div class="form-group">
-                    <label asp-for="Post.PublishDateTime" class="control-label"></label>
-                    <input asp-for="Post.PublishDateTime" class="form-control" />
-                    <span asp-validation-for="Post.PublishDateTime" class="text-danger"></span>
+
+                <div class="form-group form-check">
+                    <label class="form-check-label">
+                        <input class="form-check-input" asp-for="Post.IsApproved" /> @Html.DisplayNameFor(model => model.Post.IsApproved)
+                    </label>
                 </div>
                 <div class="form-group">
                     <label asp-for="Post.CategoryId" class="control-label"></label>
                     <select asp-for="Post.CategoryId" class="form-control">
-                        @foreach (var category in Model.CategoryOptions)
+
+                        @foreach (Category category in Model.CategoryOptions)
                         {
                             <option value="@category.Id">@category.Name</option>
                         }
                     </select>
                     <span asp-validation-for="Post.CategoryId" class="text-danger"></span>
                 </div>
+
                 <div class="form-group">
-                    <label asp-for="Post.Content" class="control-label"></label>
-                    <textarea asp-for="Post.Content" rows="15" class="form-control post__content-input"></textarea>
-                    <span asp-validation-for="Post.Content" class="text-danger"></span>
-                </div>
-                <div class="form-group">
-                    <input type="submit" value="SAVE" class="btn btn-primary btn-block" />
+                    <input type="submit" value="Save" class="btn btn-primary" />
                 </div>
             </form>
         </div>
-    </div>
 
+    </div>
     <div>
-        <a asp-action="Index">Cancel</a>
+        <a asp-action="UserIndex">Cancel</a>
     </div>
 </div>
+
 
 @section Scripts {
     @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}

--- a/TabloidMVC/Views/Post/Edit.cshtml
+++ b/TabloidMVC/Views/Post/Edit.cshtml
@@ -30,11 +30,15 @@
                     <input asp-for="Post.ImageLocation" class="form-control" />
                     <span asp-validation-for="Post.ImageLocation" class="text-danger"></span>
                 </div>
-
+                <div class="form-group">
+                    <label asp-for="Post.PublishDateTime" class="control-label"></label>
+                    <input asp-for="Post.PublishDateTime" max="@DateTime.Now.ToShortDateString()" class="form-control" />
+                    <span asp-validation-for="Post.PublishDateTime" class="text-danger"></span>
+                </div>
                 <div class="form-group form-check">
-                    <label class="form-check-label">
-                        <input class="form-check-input" asp-for="Post.IsApproved" /> @Html.DisplayNameFor(model => model.Post.IsApproved)
-                    </label>
+
+                    <input class="form-check-input" type="hidden" asp-for="Post.IsApproved" />
+
                 </div>
                 <div class="form-group">
                     <label asp-for="Post.CategoryId" class="control-label"></label>

--- a/TabloidMVC/Views/Post/UserIndex.cshtml
+++ b/TabloidMVC/Views/Post/UserIndex.cshtml
@@ -1,12 +1,11 @@
 ﻿@model IEnumerable<TabloidMVC.Models.Post>
 
 @{
-    ViewData["Title"] = "Index";
+    ViewData["Title"] = "UserIndex";
 }
 
-
 <div class="container pt-5">
-    <h1>Posts</h1>
+    <h1>User's Posts</h1>
 
     <p>
         <a class="btn btn-primary" asp-action="Create">New Post</a>
@@ -14,14 +13,19 @@
     <table class="table table-striped">
         <thead>
             <tr>
+
                 <th>
                     @Html.DisplayNameFor(model => model.Title)
                 </th>
-                <th>
-                    @Html.DisplayNameFor(model => model.UserProfileId)
-                </th>
+
+
+
+
                 <th>
                     @Html.DisplayNameFor(model => model.CategoryId)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.UserProfileId)
                 </th>
                 <th>
                     @Html.DisplayNameFor(model => model.PublishDateTime)
@@ -33,14 +37,16 @@
             @foreach (var item in Model)
             {
                 <tr>
+
                     <td>
                         @Html.DisplayFor(modelItem => item.Title)
                     </td>
-                    <td>
-                        @Html.DisplayFor(modelItem => item.UserProfile.DisplayName)
-                    </td>
+
                     <td>
                         @Html.DisplayFor(modelItem => item.Category.Name)
+                    </td>
+                    <td>
+                        @Html.DisplayFor(modelItem => item.UserProfile.DisplayName)
                     </td>
                     <td>
                         @Html.DisplayFor(modelItem => item.PublishDateTime)
@@ -49,7 +55,12 @@
                         <a asp-action="Details" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="View">
                             <i class="fas fa-eye"></i>
                         </a>
-                        
+                        <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Edit">
+                            <i class="fas fa-pencil-alt"></i>
+                        </a>
+                        <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Delete">
+                            <i class="fas fa-trash"></i>
+                        </a>
                     </td>
                 </tr>
             }

--- a/TabloidMVC/Views/Shared/_Layout.cshtml
+++ b/TabloidMVC/Views/Shared/_Layout.cshtml
@@ -24,21 +24,48 @@
                     <ul class="navbar-nav ml-auto">
                         @if (User.Identity.IsAuthenticated)
                         {
-                            <li class="nav-item mx-0 mx-lg-1">
-                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Home" asp-action="Index">HOME</a>
-                            </li>
-                            <li class="nav-item mx-0 mx-lg-1">
-                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Post" asp-action="Index">POSTS</a>
-                            </li>
-                            <li class="nav-item mx-0 mx-lg-1">
-                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Account" asp-action="Logout">LOGOUT</a>
-                            </li>
+                            @if (User.IsInRole("Admin"))
+                            {
+
+
+                                <li class="nav-item mx-0 mx-lg-1">
+                                    <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Home" asp-action="Index">HOME</a>
+                                </li>
+                                <li class="nav-item mx-0 mx-lg-1">
+                                    <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Post" asp-action="Index">POSTS</a>
+                                </li>
+                                <li class="nav-item mx-0 mx-lg-1">
+                                    <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Post" asp-action="UserIndex">MY POSTS</a>
+                                </li>
+                                <li class="nav-item mx-0 mx-lg-1">
+                                    <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="User" asp-action="Index">USER PROFILES</a>
+                                </li>
+                                <li class="nav-item mx-0 mx-lg-1">
+                                    <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Account" asp-action="Logout">LOGOUT</a>
+                                </li>
+                            }
+                            else
+                            {
+                                <li class="nav-item mx-0 mx-lg-1">
+                                    <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Home" asp-action="Index">HOME</a>
+                                </li>
+                                <li class="nav-item mx-0 mx-lg-1">
+                                    <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Post" asp-action="Index">POSTS</a>
+                                </li>
+                                <li class="nav-item mx-0 mx-lg-1">
+                                    <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Post" asp-action="UserIndex">MY POSTS</a>
+                                </li>
+                                <li class="nav-item mx-0 mx-lg-1">
+                                    <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Account" asp-action="Logout">LOGOUT</a>
+                                </li>
+                            }
+                        
                         }
                         else
                         {
-                            <li class="nav-item mx-0 mx-lg-1">
-                                <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Account" asp-action="Login">LOGIN</a>
-                            </li>
+                        <li class="nav-item mx-0 mx-lg-1">
+                            <a class="nav-link py-3 px-0 px-lg-3 rounded js-scroll-trigger" asp-area="" asp-controller="Account" asp-action="Login">LOGIN</a>
+                        </li>
                         }
                     </ul>
                 </div>

--- a/TabloidMVC/Views/User/Index.cshtml
+++ b/TabloidMVC/Views/User/Index.cshtml
@@ -1,0 +1,63 @@
+﻿@model IEnumerable<TabloidMVC.Models.UserProfile>
+
+@{
+    ViewData["Title"] = "Index";
+}
+
+
+<div class="container pt-5">
+    <h1>Index</h1>
+    <p>
+        <a class="btn btn-primary" asp-action="Create">Create New</a>
+    </p>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+
+
+                <th>
+                    @Html.DisplayNameFor(model => model.DisplayName)
+                </th>
+                <th>
+                    @Html.DisplayNameFor(model => model.FullName)
+                </th>
+
+                <th>
+                    @Html.DisplayNameFor(model => model.UserTypeId)
+                </th>
+
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var item in Model)
+            {
+                <tr>
+
+                    <td>
+                        @Html.DisplayFor(modelItem => item.DisplayName)
+                    </td>
+                    <td>
+                        @Html.DisplayFor(modelItem => item.FullName)
+                    </td>
+
+                    <td>
+                        @Html.DisplayFor(modelItem => item.UserType.Name)
+                    </td>
+
+                    <td>
+                        <a asp-action="Details" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="View">
+                            <i class="fas fa-eye"></i>
+                        </a>
+                        <a asp-action="Edit" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Edit">
+                            <i class="fas fa-pencil-alt"></i>
+                        </a>
+                        <a asp-action="Delete" asp-route-id="@item.Id" class="btn btn-outline-primary mx-1" title="Delete">
+                            <i class="fas fa-trash"></i>
+                        </a>
+                    </td>
+                </tr>
+            }
+        </tbody>
+    </table>
+</div>


### PR DESCRIPTION
# Description
Allows user to see just their posts, edit posts and soft delete posts, Posts now show estimated read time, and admin can see all user profiles.
## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions
Git fetch --all
Git checkout into th-Post/User
Login with admin@example.com
Go to my Posts and you should see only your blog posts.
Click the eye button on a post and at the top right should be the estimated read time.
You can click the pen button to edit the posts and it will redirect you to the post details after you are done.
You can click the trash can to delete posts but they will remain in the database.

If logged in as an admin you should see USER PROFILES menu option at the top of the page. 
Once clicked it should show a list of all users on the platform.
# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works