### PR TITLE
fixed user type edit issue

### DIFF
--- a/TabloidMVC/Controllers/UserController.cs
+++ b/TabloidMVC/Controllers/UserController.cs
@@ -116,7 +116,7 @@ namespace TabloidMVC.Controllers
         // GET: UserController/Delete/5
         public ActionResult Deactivate(int id)
         {
-            var user = _userRepo.GetUserProfileById(id);
+            UserProfile user = _userRepo.GetUserProfileById(id);
             if (user != null)
             {
                 return View(user);
@@ -133,9 +133,10 @@ namespace TabloidMVC.Controllers
         [ValidateAntiForgeryToken]
         public ActionResult Deactivate(UserProfile profile )
         {
+            UserProfile userId = _userRepo.GetUserProfileById(profile.Id);
             try
             {
-                if(profile.UserTypeId == 2)
+                if(userId.UserTypeId == 1)
                 {
                     List<UserProfile> admins = _userRepo.GetAllAdminUserProfiles();
                     if (admins.Count <= 1)

--- a/TabloidMVC/Controllers/UserController.cs
+++ b/TabloidMVC/Controllers/UserController.cs
@@ -75,26 +75,36 @@ namespace TabloidMVC.Controllers
         {
             try
             {
-                List<UserProfile> admins = _userRepo.GetAllAdminUserProfiles();
-                if(admins.Count <= 1)
-                {
-                    ModelState.AddModelError("Profile.UserTypeId", "There can not be less than 1 Admin. Must give Admin rights to someone else before this action will work.");
-                    UserProfile profile = _userRepo.GetUserProfileById(vm.Profile.Id);
-                    List<UserType> types = _userTypeReop.GetAllUserTypes();
 
-                    UserProfileViewModel upvm = new UserProfileViewModel
+                if (vm.Profile.UserTypeId == 2)
+                {
+
+
+                    List<UserProfile> admins = _userRepo.GetAllAdminUserProfiles();
+                    if (admins.Count <= 1)
                     {
-                        Profile = profile,
-                        UserTypes = types
-                    };
-                    return View(upvm);
+                        ModelState.AddModelError("Profile.UserTypeId", "There can not be less than 1 Admin. Must give Admin rights to someone else before this action will work.");
+                        UserProfile profile = _userRepo.GetUserProfileById(vm.Profile.Id);
+                        List<UserType> types = _userTypeReop.GetAllUserTypes();
+
+                        UserProfileViewModel upvm = new UserProfileViewModel
+                        {
+                            Profile = profile,
+                            UserTypes = types
+                        };
+                        return View(upvm);
+                    }
+                    else
+                    {
+                        _userRepo.UpdateUserType(vm.Profile.Id, vm.Profile.UserTypeId);
+                        return RedirectToAction("Index");
+                    }
                 }
                 else
                 {
                     _userRepo.UpdateUserType(vm.Profile.Id, vm.Profile.UserTypeId);
                     return RedirectToAction("Index");
                 }
-               
             }
             catch
             {
@@ -125,18 +135,28 @@ namespace TabloidMVC.Controllers
         {
             try
             {
-                List<UserProfile> admins = _userRepo.GetAllAdminUserProfiles();
-                if (admins.Count <= 1)
+                if(profile.UserTypeId == 2)
                 {
-                    ModelState.AddModelError("UserType", "There can not be less than 1 Admin. Must give Admin rights to someone else before this action will work.");
-                    var user = _userRepo.GetUserProfileById(profile.Id);
-                    return View(user);
+                    List<UserProfile> admins = _userRepo.GetAllAdminUserProfiles();
+                    if (admins.Count <= 1)
+                    {
+                        ModelState.AddModelError("UserType", "There can not be less than 1 Admin. Must give Admin rights to someone else before this action will work.");
+                        var user = _userRepo.GetUserProfileById(profile.Id);
+                        return View(user);
+                    }
+                    else
+                    {
+                        _userRepo.DeactivateProfile(profile.Id);
+                        return RedirectToAction("Index");
+                    }
                 }
                 else
                 {
                     _userRepo.DeactivateProfile(profile.Id);
                     return RedirectToAction("Index");
+
                 }
+
                
             }
             catch

--- a/TabloidMVC/Repositories/PostRepository.cs
+++ b/TabloidMVC/Repositories/PostRepository.cs
@@ -34,7 +34,8 @@ namespace TabloidMVC.Repositories
                               LEFT JOIN Category c ON p.CategoryId = c.id
                               LEFT JOIN UserProfile u ON p.UserProfileId = u.id
                               LEFT JOIN UserType ut ON u.UserTypeId = ut.id
-                        WHERE IsApproved = 1 AND PublishDateTime < SYSDATETIME() AND  p.IsDeleted = 0";
+                        WHERE IsApproved = 1 AND PublishDateTime < SYSDATETIME() AND  p.IsDeleted = 0
+                        ORDER BY p.CreateDateTime DESC";
                     var reader = cmd.ExecuteReader();
 
                     var posts = new List<Post>();
@@ -114,7 +115,7 @@ namespace TabloidMVC.Repositories
                               LEFT JOIN UserType ut ON u.UserTypeId = ut.id
                        
                         WHERE p.UserProfileId = @userProfileId AND  p.IsDeleted = 0
-                        ORDER BY p.CreateDateTime";
+                        ORDER BY p.CreateDateTime DESC";
 
                     
                     cmd.Parameters.AddWithValue("@userProfileId", userProfileId);


### PR DESCRIPTION
The user should be able to make authors admins as intended. The Check for if there was only one admin was triggering if there was one admin but they wanted to create additional admins instead of only triggering when trying to change the last admin to an author.