### PR TITLE
Sf refactor

### DIFF
--- a/TabloidMVC/Controllers/CommentController.cs
+++ b/TabloidMVC/Controllers/CommentController.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using TabloidMVC.Models;
@@ -10,7 +11,7 @@ using TabloidMVC.Models.ViewModels;
 using TabloidMVC.Repositories;
 
 namespace TabloidMVC.Controllers
-{
+{  [Authorize]
     public class CommentController : Controller
     {
         private readonly ICommentRepository _commentRepository;
@@ -25,17 +26,15 @@ namespace TabloidMVC.Controllers
         public ActionResult Index(int id)
         {
             Post post = _postRepository.GetPublishedPostById(id);
-            Comment comment = _commentRepository.GetCommentById(id);
             List<Comment> comments = _commentRepository.GetAllCommentsByPostId(id);
-            if (post == null || comment == null || comments == null)
-            {
-                return NotFound();
-            }
+            //if (post == null || comment == null || comments == null)
+            //{
+            //    return NotFound();
+            //}
 
             PostCommentViewModel vm = new PostCommentViewModel
             {
                 Post = post,
-                Comment = comment,
                 Comments = comments
             };
 

--- a/TabloidMVC/Controllers/CommentController.cs
+++ b/TabloidMVC/Controllers/CommentController.cs
@@ -25,11 +25,13 @@ namespace TabloidMVC.Controllers
         public ActionResult Index(int id)
         {
             Post post = _postRepository.GetPublishedPostById(id);
+            Comment comment = _commentRepository.GetCommentById(id);
             List<Comment> comments = _commentRepository.GetAllCommentsByPostId(id);
 
             PostCommentViewModel vm = new PostCommentViewModel
             {
                 Post = post,
+                Comment = comment,
                 Comments = comments
             };
 
@@ -40,7 +42,15 @@ namespace TabloidMVC.Controllers
         public ActionResult Details(int id)
         {
             Comment comment = _commentRepository.GetCommentById(id);
-            return View(comment);
+            Post post = _postRepository.GetPublishedPostById(comment.PostId);
+            
+            PostCommentViewModel vm = new PostCommentViewModel
+            {
+                Post = post,
+                Comment = comment 
+            };
+
+            return View(vm);
         }
 
         // GET: CommentsController/Create

--- a/TabloidMVC/Controllers/CommentController.cs
+++ b/TabloidMVC/Controllers/CommentController.cs
@@ -27,10 +27,10 @@ namespace TabloidMVC.Controllers
         {
             Post post = _postRepository.GetPublishedPostById(id);
             List<Comment> comments = _commentRepository.GetAllCommentsByPostId(id);
-            //if (post == null || comment == null || comments == null)
-            //{
-            //    return NotFound();
-            //}
+            if (post == null || comments == null)
+            {
+                return NotFound();
+            }
 
             PostCommentViewModel vm = new PostCommentViewModel
             {
@@ -44,8 +44,9 @@ namespace TabloidMVC.Controllers
         // GET: CommentsController/Details/5
         public ActionResult Details(int id)
         {
+            int userId = GetCurrentUserProfileId();
             Comment comment = _commentRepository.GetCommentById(id);
-            if (comment == null)
+            if (comment == null || comment.UserProfileId != userId)
             {
                 return NotFound();
             }
@@ -89,11 +90,13 @@ namespace TabloidMVC.Controllers
         // GET: CommentsController/Edit/5
         public ActionResult Edit(int id)
         {
+            int userId = GetCurrentUserProfileId();
             Comment comment = _commentRepository.GetCommentById(id);
-            if (comment == null)
+            if (comment.UserProfileId != userId || comment == null )
             {
                 return NotFound();
             }
+           
             return View(comment);
         }
 
@@ -119,8 +122,10 @@ namespace TabloidMVC.Controllers
         // GET: CommentsController/Delete/5
         public ActionResult Delete(int id)
         {
+            int userId = GetCurrentUserProfileId();
             Comment comment =  _commentRepository.GetCommentById(id);
-            if (comment == null)
+
+            if (comment.UserProfileId != userId || comment == null)
             {
                 return NotFound();
             }

--- a/TabloidMVC/Controllers/CommentController.cs
+++ b/TabloidMVC/Controllers/CommentController.cs
@@ -27,6 +27,10 @@ namespace TabloidMVC.Controllers
             Post post = _postRepository.GetPublishedPostById(id);
             Comment comment = _commentRepository.GetCommentById(id);
             List<Comment> comments = _commentRepository.GetAllCommentsByPostId(id);
+            if (post == null || comment == null || comments == null)
+            {
+                return NotFound();
+            }
 
             PostCommentViewModel vm = new PostCommentViewModel
             {
@@ -42,8 +46,12 @@ namespace TabloidMVC.Controllers
         public ActionResult Details(int id)
         {
             Comment comment = _commentRepository.GetCommentById(id);
+            if (comment == null)
+            {
+                return NotFound();
+            }
             Post post = _postRepository.GetPublishedPostById(comment.PostId);
-            
+        
             PostCommentViewModel vm = new PostCommentViewModel
             {
                 Post = post,
@@ -83,6 +91,10 @@ namespace TabloidMVC.Controllers
         public ActionResult Edit(int id)
         {
             Comment comment = _commentRepository.GetCommentById(id);
+            if (comment == null)
+            {
+                return NotFound();
+            }
             return View(comment);
         }
 
@@ -109,6 +121,10 @@ namespace TabloidMVC.Controllers
         public ActionResult Delete(int id)
         {
             Comment comment =  _commentRepository.GetCommentById(id);
+            if (comment == null)
+            {
+                return NotFound();
+            }
             return View(comment);
         }
 

--- a/TabloidMVC/Models/Comment.cs
+++ b/TabloidMVC/Models/Comment.cs
@@ -16,6 +16,8 @@ namespace TabloidMVC.Models
         [DisplayName("Author")]
         public int UserProfileId { get; set; }
         public string Subject { get; set; }
+
+        [DisplayName("Comment")]
         public string Content { get; set; }
 
         [DataType(DataType.Date)]

--- a/TabloidMVC/Models/Comment.cs
+++ b/TabloidMVC/Models/Comment.cs
@@ -15,8 +15,11 @@ namespace TabloidMVC.Models
 
         [DisplayName("Author")]
         public int UserProfileId { get; set; }
+
+        [Required]
         public string Subject { get; set; }
 
+        [Required]
         [DisplayName("Comment")]
         public string Content { get; set; }
 

--- a/TabloidMVC/Models/Post.cs
+++ b/TabloidMVC/Models/Post.cs
@@ -35,7 +35,7 @@ namespace TabloidMVC.Models
         public int UserProfileId { get; set; }
         public UserProfile UserProfile { get; set; }
 
-
+        
 
         
 

--- a/TabloidMVC/Models/ViewModels/PostCommentViewModel.cs
+++ b/TabloidMVC/Models/ViewModels/PostCommentViewModel.cs
@@ -8,6 +8,7 @@ namespace TabloidMVC.Models.ViewModels
     public class PostCommentViewModel
     {
         public Post Post { get; set; }
+        public Comment Comment { get; set; }
         public List<Comment> Comments { get; set; }
     }
 }

--- a/TabloidMVC/Repositories/CommentRepository.cs
+++ b/TabloidMVC/Repositories/CommentRepository.cs
@@ -97,7 +97,17 @@ namespace TabloidMVC.Repositories
                             UserProfileId = reader.GetInt32(reader.GetOrdinal("UserProfileId")),
                             Subject = reader.GetString(reader.GetOrdinal("Subject")),
                             Content = reader.GetString(reader.GetOrdinal("Content")),
-                            CreateDateTime = reader.GetDateTime(reader.GetOrdinal("CreateDateTime"))
+                            CreateDateTime = reader.GetDateTime(reader.GetOrdinal("CreateDateTime")),
+                            Post = new Post
+                            {
+                                Id = reader.GetInt32(reader.GetOrdinal("PostId")),
+                                Title = reader.GetString(reader.GetOrdinal("Title"))
+                            },
+                            UserProfile = new UserProfile
+                            {
+                                Id = reader.GetInt32(reader.GetOrdinal("UserProfileId")),
+                                DisplayName = reader.GetString(reader.GetOrdinal("DisplayName"))
+                            }
 
                         };
 

--- a/TabloidMVC/Views/Comment/Delete.cshtml
+++ b/TabloidMVC/Views/Comment/Delete.cshtml
@@ -6,22 +6,11 @@
 
 <h1>Delete</h1>
 
-<h3>Are you sure you want to delete this comment?</h3>
+<h3>Are you sure you want to delete this?</h3>
 <div>
+    <h4>Comment</h4>
     <hr />
     <dl class="row">
-        @*<dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.Id)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.Id)
-        </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.PostId)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.PostId)
-        </dd>*@
         <dt class = "col-sm-2">
             @Html.DisplayNameFor(model => model.Subject)
         </dt>

--- a/TabloidMVC/Views/Comment/Delete.cshtml
+++ b/TabloidMVC/Views/Comment/Delete.cshtml
@@ -28,6 +28,6 @@
     
     <form asp-action="Delete">
         <input type="submit" value="Delete" class="btn btn-danger" /> |
-        <button type="button" class="btn btn-outline-primary">@Html.ActionLink("Back To List", "Index", "Comment", new { id = @Model.PostId })</button>
+        @Html.ActionLink("Back To List", "Index", "Comment", new { id = @Model.PostId })
     </form>
 </div>

--- a/TabloidMVC/Views/Comment/Details.cshtml
+++ b/TabloidMVC/Views/Comment/Details.cshtml
@@ -1,30 +1,35 @@
-﻿@model TabloidMVC.Models.Comment
+﻿@model TabloidMVC.Models.ViewModels.PostCommentViewModel
 
 @{
     ViewData["Title"] = "Details";
 }
 
-<h1>Details</h1>
+<div class="container pt-5">
+    <h1>@Model.Post.Title</h1>
 
-<div>
-    <h4>Comment</h4>
-    <hr />
-    <dl class="row">
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.Subject)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.Subject)
-        </dd>
-        <dt class = "col-sm-2">
-            @Html.DisplayNameFor(model => model.Content)
-        </dt>
-        <dd class = "col-sm-10">
-            @Html.DisplayFor(model => model.Content)
-        </dd>
-    </dl>
-</div>
-<div>
-    @*@Html.ActionLink("Back To Edit", "Edit", "Comment", new { id = Model.Id }) |*@
-    @Html.ActionLink("Back To List", "Index", "Comment", new { id = Model.PostId }) |
+    <div>
+        <p>Written by @Model.Comment.UserProfile.DisplayName</p>
+        <h5>Your Edited Comment</h5>
+        <hr />
+
+        <dl class="row">
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => model.Comment.Subject)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.Comment.Subject)
+            </dd>
+            <dt class="col-sm-2">
+                @Html.DisplayNameFor(model => model.Comment.Content)
+            </dt>
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.Comment.Content)
+            </dd>
+        </dl>
+    </div>
+
+    <div>
+        @*@Html.ActionLink("Back To Edit", "Edit", "Comment", new { id = Model.Id }) |*@
+        @Html.ActionLink("Back To List", "Index", "Comment", new { id = Model.Comment.PostId }) |
+    </div>
 </div>

--- a/TabloidMVC/Views/Comment/Edit.cshtml
+++ b/TabloidMVC/Views/Comment/Edit.cshtml
@@ -35,7 +35,7 @@
         </div>
     </div>
     <div>
-        <button type="button" class="btn btn-outline-primary">@Html.ActionLink("Cancel", "Index", "Comment", new { id = @Model.PostId })</button>
+        @Html.ActionLink("Cancel", "Index", "Comment", new { id = @Model.PostId })
     </div>
 </div>
 

--- a/TabloidMVC/Views/Comment/Edit.cshtml
+++ b/TabloidMVC/Views/Comment/Edit.cshtml
@@ -4,40 +4,41 @@
     ViewData["Title"] = "Edit";
 }
 
-<h1>Edit</h1>
-
-<h4>Comment</h4>
 <hr />
-<div class="row">
-    <div class="col-md-4">
-        <form asp-action="Edit">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-            <div class="form-group">
-                <input asp-for="Id" type="hidden" class="form-control" />
-            </div>
-            <div class="form-group">
-                <input asp-for="PostId" type="hidden" class="form-control" />
-            </div>
-            <div class="form-group">
-                <label asp-for="Subject" class="control-label"></label>
-                <input asp-for="Subject" class="form-control" />
-                <span asp-validation-for="Subject" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <label asp-for="Content" class="control-label"></label>
-                <textarea asp-for="Content" class="form-control"></textarea>
-                <span asp-validation-for="Content" class="text-danger"></span>
-            </div>
-            <div class="form-group">
-                <input type="submit" value="Save" class="btn btn-primary" />
-            </div>
-           
-            <button type="button" class="btn btn-outline-primary">@Html.ActionLink("Back To List", "Index", "Comment", new { id = @Model.PostId })</button> 
-          
-        </form>
+<div class="container pt-5">
+    <div class="row justify-content-center">
+        <div class=" card col-md-4">
+            <h3 class="mt-3 text-primary text-center card-title">What do you want to edit?</h3>
+            <form asp-action="Edit">
+                <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+                <div class="form-group">
+                    <input asp-for="Id" type="hidden" class="form-control" />
+                </div>
+                <div class="form-group">
+                    <input asp-for="PostId" type="hidden" class="form-control" />
+                </div>
+                <div class="form-group">
+                    <label asp-for="Subject" class="control-label"></label>
+                    <input asp-for="Subject" class="form-control" />
+                    <span asp-validation-for="Subject" class="text-danger"></span>
+                </div>
+                <div class="form-group">
+                    <label asp-for="Content" class="control-label"></label>
+                    <textarea asp-for="Content" rows="15" class="form-control"></textarea>
+                    <span asp-validation-for="Content" class="text-danger"></span>
+                </div>
+                <div class="form-group">
+                    <input type="submit" value="Save" class="btn btn-primary" />
+                </div>
+
+            </form>
+        </div>
+    </div>
+    <div>
+        <button type="button" class="btn btn-outline-primary">@Html.ActionLink("Cancel", "Index", "Comment", new { id = @Model.PostId })</button>
     </div>
 </div>
 
-@section Scripts {
-    @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
-}
+    @section Scripts {
+        @{await Html.RenderPartialAsync("_ValidationScriptsPartial");}
+    }

--- a/TabloidMVC/Views/Comment/Index.cshtml
+++ b/TabloidMVC/Views/Comment/Index.cshtml
@@ -14,16 +14,16 @@
         <thead>
             <tr>
                 <th>
-                    @Html.DisplayNameFor(model => model.Comment.UserProfileId)
+                    Author
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => model.Comment.Subject)
+                   Subject
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => model.Comment.Content)
+                    Comment
                 </th>
                 <th>
-                    @Html.DisplayNameFor(model => model.Comment.CreateDateTime)
+                    Date Written
                 </th>
                 <th></th>
             </tr>
@@ -45,12 +45,20 @@
                         @Html.DisplayFor(modelItem => comment.CreateDateTime)
                     </td>
                     <td>
-                        <a asp-action="Edit" asp-route-id="@comment.Id" class="btn btn-outline-primary mx-1" title="Edit">
-                            <i class="fas fa-pencil-alt"></i>
-                        </a>
-                        <a asp-action="Delete" asp-route-id="@comment.Id" class="btn btn-outline-primary mx-1" title="Delete">
-                            <i class="fas fa-trash"></i>
-                        </a>
+                        @if (comment.UserProfileId == int.Parse(User.Claims.ElementAt(0).Value))
+                        {
+                            <a asp-action="Edit" asp-route-id="@comment.Id" class="btn btn-outline-primary mx-1" title="Edit">
+                                <i class="fas fa-pencil-alt"></i>
+                            </a>
+                            <a asp-action="Delete" asp-route-id="@comment.Id" class="btn btn-outline-primary mx-1" title="Delete">
+                                <i class="fas fa-trash"></i>
+                            </a>
+                        }
+                        else
+                        {
+                            <div></div>
+                        }
+
                     </td>
                 </tr>
             }

--- a/TabloidMVC/Views/Comment/Index.cshtml
+++ b/TabloidMVC/Views/Comment/Index.cshtml
@@ -14,16 +14,16 @@
         <thead>
             <tr>
                 <th>
-                    Author
+                    @Html.DisplayNameFor(model => model.Comment.UserProfileId)
                 </th>
                 <th>
-                    Subject
+                    @Html.DisplayNameFor(model => model.Comment.Subject)
                 </th>
                 <th>
-                    Comment
+                    @Html.DisplayNameFor(model => model.Comment.Content)
                 </th>
                 <th>
-                    Date Written
+                    @Html.DisplayNameFor(model => model.Comment.CreateDateTime)
                 </th>
                 <th></th>
             </tr>

--- a/TabloidMVC/Views/Comment/Index.cshtml
+++ b/TabloidMVC/Views/Comment/Index.cshtml
@@ -14,16 +14,16 @@
         <thead>
             <tr>
                 <th>
-                    Author
+                   Author
                 </th>
                 <th>
                    Subject
                 </th>
                 <th>
-                    Comment
+                   Comment
                 </th>
                 <th>
-                    Date Written
+                   Date Written
                 </th>
                 <th></th>
             </tr>


### PR DESCRIPTION
# Description
1. Authorization implemented so that only the user that owns the comments can edit and delete them
2. Only logged in users that own the comments can view the respective comment pages
3. Took out the buttons for back to list and cancel; now should be just a hyperlink

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions
1. pull down sf-refactor
2. Log in as one user and then log in as another; should not be able to edit or delete any of the comments 
3. Try to type in url for edit or detail pertaining to a comment not owned by the current user and it should display 404 not found
# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works